### PR TITLE
Fix GenericSliderSettingTag.cpp and write git info as header instead of compile definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ mod.json
 *.psd
 .vscode/
 .cache/
+include/git_info.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,11 +39,18 @@ message(STATUS "GIT_BRANCH: ${GIT_BRANCH}")
 message(STATUS "GIT_COMMIT: 0x${GIT_COMMIT}")
 message(STATUS "GIT_MODIFIED: ${GIT_MODIFIED}")
 
-# set git defines
-add_compile_definitions(GIT_USER=\"${GIT_USER}\")
-add_compile_definitions(GIT_BRANCH=\"${GIT_BRANCH}\")
-add_compile_definitions(GIT_COMMIT=0x${GIT_COMMIT})
-add_compile_definitions(GIT_MODIFIED=${GIT_MODIFIED})
+set(GIT_INFO_H "#pragma once
+#define GIT_USER \"${GIT_USER}\"
+#define GIT_BRANCH \"${GIT_BRANCH}\"
+#define GIT_COMMIT 0x${GIT_COMMIT}
+#define GIT_MODIFIED ${GIT_MODIFIED}
+")
+
+# write git info to file if the contents have changed
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/git_info.h" GIT_INFO_H_CURRENT)
+if(NOT "${GIT_INFO_H}" STREQUAL "${GIT_INFO_H_CURRENT}")
+    file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/include/git_info.h" "${GIT_INFO_H}")
+endif()
 
 # compile definitions used
 add_compile_definitions(VERSION=\"${MOD_VERSION}\")

--- a/qpm.json
+++ b/qpm.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/QuestPackageManager/QPM.Package/refs/heads/main/qpm.schema.json",
   "version": "0.4.0",
   "sharedDir": "shared",
   "dependenciesDir": "extern",
@@ -32,7 +33,11 @@
         "pwsh ./scripts/createqmod.ps1 BSML -clean"
       ]
     },
-    "qmodIncludeDirs": [],
+    "ndk": "^27.2.12479018",
+    "qmodIncludeDirs": [
+      "build",
+      "extern/libs"
+    ],
     "qmodIncludeFiles": [],
     "qmodOutput": null
   },

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/QuestPackageManager/QPM.Package/refs/heads/main/qpm.shared.schema.json",
   "config": {
     "version": "0.4.0",
     "sharedDir": "shared",
@@ -33,7 +34,11 @@
           "pwsh ./scripts/createqmod.ps1 BSML -clean"
         ]
       },
-      "qmodIncludeDirs": [],
+      "ndk": "^27.2.12479018",
+      "qmodIncludeDirs": [
+        "build",
+        "extern/libs"
+      ],
       "qmodIncludeFiles": [],
       "qmodOutput": null
     },

--- a/src/BSML/Tags/Settings/GenericSliderSettingTag.cpp
+++ b/src/BSML/Tags/Settings/GenericSliderSettingTag.cpp
@@ -62,7 +62,7 @@ namespace BSML {
         auto nameText = gameObject->get_transform()->Find("Title")->get_gameObject();
         Object::Destroy(nameText->GetComponent<BGLib::Polyglot::LocalizedTextMeshProUGUI*>());
 
-        auto titleTransform = nameText->get_transform()->gameObject->transform.cast<RectTransform>();
+        auto titleTransform = nameText->get_transform().cast<RectTransform>();
         titleTransform->set_anchorMin({0, 0});
         titleTransform->set_anchorMax({0, 0});
         titleTransform->set_offsetMin({0, 0});

--- a/src/BSML/Tags/Settings/GenericSliderSettingTag.cpp
+++ b/src/BSML/Tags/Settings/GenericSliderSettingTag.cpp
@@ -32,6 +32,11 @@ namespace BSML {
         auto gameObject = baseSetting->get_gameObject();
         gameObject->set_name("BSMLSliderSetting");
 
+        auto rectTransform = baseSetting->transform.cast<RectTransform>();
+        rectTransform->set_anchoredPosition({0, 0});
+        Object::Destroy(rectTransform->Find("SliderLeft")->gameObject);
+        Object::Destroy(baseSetting->GetComponent<CanvasGroup*>());
+
         auto sliderSetting = gameObject->AddComponent(get_type()).cast<BSML::SliderSettingBase>();
         auto slider = gameObject->GetComponentInChildren<HMUI::CustomFormatRangeValuesSlider*>();
         sliderSetting->slider = slider;
@@ -57,10 +62,19 @@ namespace BSML {
         auto nameText = gameObject->get_transform()->Find("Title")->get_gameObject();
         Object::Destroy(nameText->GetComponent<BGLib::Polyglot::LocalizedTextMeshProUGUI*>());
 
+        auto titleTransform = nameText->get_transform()->gameObject->transform.cast<RectTransform>();
+        titleTransform->set_anchorMin({0, 0});
+        titleTransform->set_anchorMax({0, 0});
+        titleTransform->set_offsetMin({0, 0});
+        titleTransform->set_offsetMax({-52, 0});
+
         TMPro::TextMeshProUGUI* text = nameText->GetComponent<TMPro::TextMeshProUGUI*>();
         text->set_richText(true);
         text->set_text("BSMLSlider");
         text->get_rectTransform()->set_anchorMax({1, 1});
+        text->set_alignment(::TMPro::TextAlignmentOptions::CaplineLeft);
+        text->set_enableWordWrapping(false);
+        text->set_overflowMode(::TMPro::TextOverflowModes::Overflow);
 
         baseSetting->set_preferredWidth(90.0f);
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,6 +1,7 @@
 #include "config.hpp"
 #include "logging.hpp"
 #include "beatsaber-hook/shared/config/config-utils.hpp"
+#include "git_info.h"
 
 
 config_t config;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "_config.h"
 #include "hooking.hpp"
 #include "logging.hpp"
+#include "git_info.h"
 
 #include "BSMLDataCache.hpp"
 #include "assets.hpp"


### PR DESCRIPTION
This PR aims to port the changes made in https://github.com/monkeymanboy/BeatSaberMarkupLanguage/commit/b25aac67022343d3982396588294f9a91d66163c#diff-ff833c2659e56473dbf4b80f4a82cf5b2fd7846bfde1f1b188afa64bbccd4d13R23

This is almost 1:1, but I had to add these lines to keep the text from wrapping
```c++
text->set_enableWordWrapping(false);
text->set_overflowMode(::TMPro::TextOverflowModes::Overflow);
```

I also updated CMakeLists.txt to output the git info as a header file rather than compile definitions, this makes partial rebuilds across git state changes possible.