### PR TITLE
Cleanup unity web requests to prevent potential crashes

### DIFF
--- a/src/Helpers/utilities.cpp
+++ b/src/Helpers/utilities.cpp
@@ -185,8 +185,14 @@ namespace BSML::Utilities {
         auto req = www->SendWebRequest();
         while (!req->get_isDone()) co_yield nullptr;
         auto error = www->GetError();
-        onFinished((error == UnityEngine::Networking::UnityWebRequest::UnityWebRequestError::OK) ? www->get_downloadHandler()->GetData() : nullptr);
+        if (error != UnityEngine::Networking::UnityWebRequest::UnityWebRequestError::OK) {
+            onFinished(nullptr);
+            www->Dispose();
+            co_return;
+        };
 
+        onFinished(www->get_downloadHandler()->GetData());
+        www->Dispose();
         co_return;
     }
 


### PR DESCRIPTION
Unity web requests need to be disposed of manually after each request. It crashed scoresaber and I brought the fix to bsml too
![image](https://github.com/user-attachments/assets/85c6368b-5e28-4955-a4a9-d15d9995ea15)
