### PR TITLE
Update BSML to work for Unity 6 (1.41.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,6 @@ endif()
 add_compile_definitions(VERSION=\"${MOD_VERSION}\")
 add_compile_definitions(MOD_ID=\"${MOD_ID}\")
 add_compile_definitions(MAKE_DOCS=${MAKE_DOCS})
-add_compile_definitions(UNITY_2021)
 add_compile_definitions(CORDL_RUNTIME_FIELD_NULL_CHECKS)
 
 # recursively get all src files

--- a/mod.template.json
+++ b/mod.template.json
@@ -1,20 +1,20 @@
 {
-    "_QPVersion": "1.1.0",
-    "name": "${mod_name}",
-    "id": "${mod_id}",
-    "modloader": "Scotland2",
-    "author": "RedBrumbler",
-    "version": "${version}",
-    "packageId": "com.beatgames.beatsaber",
-    "packageVersion": "1.40.8_7379",
-    "coverImage": "cover.png",
-    "description": "Library that parses BeatSaber Markup Language to create UI elements",
-    "dependencies": [],
-    "modFiles": [
-        "${binary}"
-    ],
-    "lateModFiles": [],
-    "libraryFiles": [],
-    "fileCopies": [],
-    "isLibrary": true
+  "_QPVersion": "1.1.0",
+  "name": "${mod_name}",
+  "id": "${mod_id}",
+  "modloader": "Scotland2",
+  "author": "RedBrumbler",
+  "version": "${version}",
+  "packageId": "com.beatgames.beatsaber",
+  "packageVersion": "1.41.0_11623",
+  "coverImage": "cover.png",
+  "description": "Library that parses BeatSaber Markup Language to create UI elements",
+  "dependencies": [],
+  "modFiles": [
+    "${binary}"
+  ],
+  "lateModFiles": [],
+  "libraryFiles": [],
+  "fileCopies": [],
+  "isLibrary": true
 }

--- a/qpm.json
+++ b/qpm.json
@@ -6,7 +6,7 @@
   "info": {
     "name": "BSML",
     "id": "bsml",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "url": "https://github.com/bsq-ports/Quest-BSML",
     "additionalData": {
       "overrideSoName": "libbsml.so",
@@ -33,7 +33,7 @@
         "pwsh ./scripts/createqmod.ps1 BSML -clean"
       ]
     },
-    "ndk": "^27.2.12479018",
+    "ndk": "^27.3.13750724",
     "qmodIncludeDirs": [
       "build",
       "extern/libs"
@@ -44,22 +44,22 @@
   "dependencies": [
     {
       "id": "libil2cpp",
-      "versionRange": "^0.4.0",
+      "versionRange": "^0.5.0",
       "additionalData": {}
     },
     {
       "id": "beatsaber-hook",
-      "versionRange": "^6.4.1",
+      "versionRange": "^7.3.0",
       "additionalData": {}
     },
     {
       "id": "bs-cordl",
-      "versionRange": "^4008.0.0",
+      "versionRange": "^4100.0.0",
       "additionalData": {}
     },
     {
       "id": "custom-types",
-      "versionRange": "^0.18.2",
+      "versionRange": "^0.19.0",
       "additionalData": {}
     },
     {
@@ -95,6 +95,11 @@
       "additionalData": {
         "private": true
       }
+    },
+    {
+      "id": "flamingo",
+      "versionRange": "=1.1.2",
+      "additionalData": {}
     }
   ]
 }

--- a/qpm.json
+++ b/qpm.json
@@ -6,7 +6,7 @@
   "info": {
     "name": "BSML",
     "id": "bsml",
-    "version": "0.6.0",
+    "version": "0.5.0",
     "url": "https://github.com/bsq-ports/Quest-BSML",
     "additionalData": {
       "overrideSoName": "libbsml.so",
@@ -98,7 +98,7 @@
     },
     {
       "id": "flamingo",
-      "versionRange": "=1.1.2",
+      "versionRange": "^1.1.2",
       "additionalData": {}
     }
   ]

--- a/qpm.json
+++ b/qpm.json
@@ -49,7 +49,7 @@
     },
     {
       "id": "beatsaber-hook",
-      "versionRange": "^7.3.0",
+      "versionRange": "^7.4.0",
       "additionalData": {}
     },
     {

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -50,7 +50,7 @@
       },
       {
         "id": "beatsaber-hook",
-        "versionRange": "^7.3.0",
+        "versionRange": "^7.4.0",
         "additionalData": {}
       },
       {
@@ -232,12 +232,13 @@
     {
       "dependency": {
         "id": "beatsaber-hook",
-        "versionRange": "=7.3.0",
+        "versionRange": "=7.4.0",
         "additionalData": {
-          "soLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.0.0/libbeatsaber-hook.so",
-          "debugSoLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.0.0/debug_libbeatsaber-hook.so",
+          "soLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v7.4.0/libbeatsaber-hook.so",
+          "debugSoLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v7.4.0/debug_libbeatsaber-hook.so",
           "overrideSoName": "libbeatsaber-hook.so",
-          "branchName": "master",
+          "modLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v7.4.0/beatsaber-hook.qmod",
+          "branchName": "version/v7_4_0",
           "compileOptions": {
             "cppFlags": [
               "-Wno-extra-qualification"
@@ -246,7 +247,7 @@
           "cmake": true
         }
       },
-      "version": "7.3.0"
+      "version": "7.4.0"
     },
     {
       "dependency": {

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -7,7 +7,7 @@
     "info": {
       "name": "BSML",
       "id": "bsml",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "url": "https://github.com/bsq-ports/Quest-BSML",
       "additionalData": {
         "overrideSoName": "libbsml.so",
@@ -34,7 +34,7 @@
           "pwsh ./scripts/createqmod.ps1 BSML -clean"
         ]
       },
-      "ndk": "^27.2.12479018",
+      "ndk": "^27.3.13750724",
       "qmodIncludeDirs": [
         "build",
         "extern/libs"
@@ -45,22 +45,22 @@
     "dependencies": [
       {
         "id": "libil2cpp",
-        "versionRange": "^0.4.0",
+        "versionRange": "^0.5.0",
         "additionalData": {}
       },
       {
         "id": "beatsaber-hook",
-        "versionRange": "^6.4.1",
+        "versionRange": "^7.3.0",
         "additionalData": {}
       },
       {
         "id": "bs-cordl",
-        "versionRange": "^4008.0.0",
+        "versionRange": "^4100.0.0",
         "additionalData": {}
       },
       {
         "id": "custom-types",
-        "versionRange": "^0.18.2",
+        "versionRange": "^0.19.0",
         "additionalData": {}
       },
       {
@@ -96,6 +96,11 @@
         "additionalData": {
           "private": true
         }
+      },
+      {
+        "id": "flamingo",
+        "versionRange": "=1.1.2",
+        "additionalData": {}
       }
     ]
   },
@@ -103,13 +108,9 @@
     {
       "dependency": {
         "id": "custom-types",
-        "versionRange": "=0.18.3",
+        "versionRange": "=0.19.0",
         "additionalData": {
-          "soLink": "https://github.com/QuestPackageManager/Il2CppQuestTypePatching/releases/download/v0.18.3/libcustom-types.so",
-          "debugSoLink": "https://github.com/QuestPackageManager/Il2CppQuestTypePatching/releases/download/v0.18.3/debug_libcustom-types.so",
           "overrideSoName": "libcustom-types.so",
-          "modLink": "https://github.com/QuestPackageManager/Il2CppQuestTypePatching/releases/download/v0.18.3/CustomTypes.qmod",
-          "branchName": "version/v0_18_3",
           "compileOptions": {
             "cppFlags": [
               "-Wno-invalid-offsetof"
@@ -118,15 +119,32 @@
           "cmake": true
         }
       },
-      "version": "0.18.3"
+      "version": "0.19.0"
+    },
+    {
+      "dependency": {
+        "id": "kaleb",
+        "versionRange": "=0.1.9",
+        "additionalData": {
+          "headersOnly": true,
+          "branchName": "version/v0_1_9",
+          "compileOptions": {
+            "cppFlags": [
+              "-DKALEB_VERSION=\"0.1.9\""
+            ]
+          },
+          "cmake": false
+        }
+      },
+      "version": "0.1.9"
     },
     {
       "dependency": {
         "id": "bs-cordl",
-        "versionRange": "=4008.0.0",
+        "versionRange": "=4100.0.1",
         "additionalData": {
           "headersOnly": true,
-          "branchName": "version/v4008_0_0",
+          "branchName": "version/v4100_0_1",
           "compileOptions": {
             "includePaths": [
               "include"
@@ -135,24 +153,24 @@
             "cppFlags": [
               "-DNEED_UNSAFE_CSHARP",
               "-fdeclspec",
-              "-DUNITY_2021",
+              "-DUNITY_6",
               "-DHAS_CODEGEN",
               "-Wno-invalid-offsetof"
             ]
           }
         }
       },
-      "version": "4008.0.0"
+      "version": "4100.0.1"
     },
     {
       "dependency": {
         "id": "paper2_scotland2",
-        "versionRange": "=4.6.4",
+        "versionRange": "=4.7.0",
         "additionalData": {
-          "soLink": "https://github.com/Fernthedev/paperlog/releases/download/v4.6.4/libpaper2_scotland2.so",
+          "soLink": "https://github.com/Fernthedev/paperlog/releases/download/v4.7.0/libpaper2_scotland2.so",
           "overrideSoName": "libpaper2_scotland2.so",
-          "modLink": "https://github.com/Fernthedev/paperlog/releases/download/v4.6.4/paper2_scotland2.qmod",
-          "branchName": "version/v4_6_4",
+          "modLink": "https://github.com/Fernthedev/paperlog/releases/download/v4.7.0/paper2_scotland2.qmod",
+          "branchName": "version/v4_7_0",
           "compileOptions": {
             "systemIncludes": [
               "shared/utfcpp/source"
@@ -161,7 +179,7 @@
           "cmake": false
         }
       },
-      "version": "4.6.4"
+      "version": "4.7.0"
     },
     {
       "dependency": {
@@ -214,13 +232,12 @@
     {
       "dependency": {
         "id": "beatsaber-hook",
-        "versionRange": "=6.4.2",
+        "versionRange": "=7.3.0",
         "additionalData": {
-          "soLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v6.4.2/libbeatsaber-hook.so",
-          "debugSoLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v6.4.2/debug_libbeatsaber-hook.so",
+          "soLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.0.0/libbeatsaber-hook.so",
+          "debugSoLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.0.0/debug_libbeatsaber-hook.so",
           "overrideSoName": "libbeatsaber-hook.so",
-          "modLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v6.4.2/beatsaber-hook.qmod",
-          "branchName": "version/v6_4_2",
+          "branchName": "master",
           "compileOptions": {
             "cppFlags": [
               "-Wno-extra-qualification"
@@ -229,12 +246,12 @@
           "cmake": true
         }
       },
-      "version": "6.4.2"
+      "version": "7.3.0"
     },
     {
       "dependency": {
         "id": "libil2cpp",
-        "versionRange": "=0.4.0",
+        "versionRange": "=0.5.0",
         "additionalData": {
           "headersOnly": true,
           "compileOptions": {
@@ -245,7 +262,21 @@
           }
         }
       },
-      "version": "0.4.0"
+      "version": "0.5.0"
+    },
+    {
+      "dependency": {
+        "id": "flamingo",
+        "versionRange": "=1.1.2",
+        "additionalData": {
+          "soLink": "https://github.com/sc2ad/Flamingo/releases/download/v1.1.2/libflamingo.so",
+          "debugSoLink": "https://github.com/sc2ad/Flamingo/releases/download/v1.1.2/debug_libflamingo.so",
+          "overrideSoName": "libflamingo.so",
+          "modLink": "https://github.com/sc2ad/Flamingo/releases/download/v1.1.2/flamingo.qmod",
+          "branchName": "version/v1_1_2"
+        }
+      },
+      "version": "1.1.2"
     },
     {
       "dependency": {
@@ -259,23 +290,6 @@
         }
       },
       "version": "0.1.6"
-    },
-    {
-      "dependency": {
-        "id": "kaleb",
-        "versionRange": "=0.1.9",
-        "additionalData": {
-          "headersOnly": true,
-          "branchName": "version/v0_1_9",
-          "compileOptions": {
-            "cppFlags": [
-              "-DKALEB_VERSION=\"0.1.9\""
-            ]
-          },
-          "cmake": false
-        }
-      },
-      "version": "0.1.9"
     }
   ]
 }

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -7,7 +7,7 @@
     "info": {
       "name": "BSML",
       "id": "bsml",
-      "version": "0.6.0",
+      "version": "0.5.0",
       "url": "https://github.com/bsq-ports/Quest-BSML",
       "additionalData": {
         "overrideSoName": "libbsml.so",
@@ -99,7 +99,7 @@
       },
       {
         "id": "flamingo",
-        "versionRange": "=1.1.2",
+        "versionRange": "^1.1.2",
         "additionalData": {}
       }
     ]

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -110,7 +110,11 @@
         "id": "custom-types",
         "versionRange": "=0.19.0",
         "additionalData": {
+          "soLink": "https://github.com/QuestPackageManager/Il2CppQuestTypePatching/releases/download/v0.19.0/libcustom-types.so",
+          "debugSoLink": "https://github.com/QuestPackageManager/Il2CppQuestTypePatching/releases/download/v0.19.0/debug_libcustom-types.so",
           "overrideSoName": "libcustom-types.so",
+          "modLink": "https://github.com/QuestPackageManager/Il2CppQuestTypePatching/releases/download/v0.19.0/CustomTypes.qmod",
+          "branchName": "version/v0_19_0",
           "compileOptions": {
             "cppFlags": [
               "-Wno-invalid-offsetof"

--- a/src/BSML-Lite/Creation/Image.cpp
+++ b/src/BSML-Lite/Creation/Image.cpp
@@ -79,7 +79,7 @@ namespace BSML::Lite {
     }
 
     UnityEngine::Sprite* ArrayToSprite(ArrayW<uint8_t> bytes) {
-        UnityEngine::Texture2D* texture = UnityEngine::Texture2D::New_ctor(0, 0, UnityEngine::TextureFormat::RGBA32, false, false);
+        UnityEngine::Texture2D* texture = UnityEngine::Texture2D::New_ctor(1, 1, UnityEngine::TextureFormat::RGBA32, false, false);
         if (UnityEngine::ImageConversion::LoadImage(texture, bytes, false)) {
             return TextureToSprite(texture);
         }

--- a/src/BSML/MenuButtons/MenuButtons.cpp
+++ b/src/BSML/MenuButtons/MenuButtons.cpp
@@ -82,7 +82,7 @@ namespace BSML {
             m->OnDisable();
         }
         auto mainFc = BSML::Helpers::GetMainFlowCoordinator();
-        mainFc->_providedLeftScreenViewController = menuButtonsViewController;
+        mainFc->____providedLeftScreenViewController = menuButtonsViewController;
         mainFc->SetLeftScreenViewController(menuButtonsViewController, HMUI::ViewController::AnimationType::None);
     }
 

--- a/src/BSML/MenuButtons/MenuButtons.cpp
+++ b/src/BSML/MenuButtons/MenuButtons.cpp
@@ -82,7 +82,7 @@ namespace BSML {
             m->OnDisable();
         }
         auto mainFc = BSML::Helpers::GetMainFlowCoordinator();
-        mainFc->____providedLeftScreenViewController = menuButtonsViewController;
+        mainFc->_providedLeftScreenViewController = menuButtonsViewController;
         mainFc->SetLeftScreenViewController(menuButtonsViewController, HMUI::ViewController::AnimationType::None);
     }
 

--- a/src/Helpers/utilities.cpp
+++ b/src/Helpers/utilities.cpp
@@ -431,7 +431,7 @@ namespace BSML::Utilities {
 
     UnityEngine::Texture2D* LoadTextureRaw(ArrayW<uint8_t> data) {
         if (data.size() > 0) {
-            auto texture = Texture2D::New_ctor(0, 0, TextureFormat::RGBA32, false, false);
+            auto texture = Texture2D::New_ctor(1, 1, TextureFormat::RGBA32, false, false);
             if (ImageConversion::LoadImage(texture, data, false))
                 return texture;
         }


### PR DESCRIPTION
# Before PR can be set to ready
- [x] update qpm.json to use release versions
   - [x] custom-types: `^0.19.0`